### PR TITLE
Remover alto máximo de galería de obras en móvil

### DIFF
--- a/assets/home.css
+++ b/assets/home.css
@@ -392,5 +392,6 @@
     grid-auto-flow: column;
     grid-template-columns: initial;
     grid-template-rows: repeat(2, auto);
+    max-height: unset;
   }
 }


### PR DESCRIPTION
Esto es para evitar el scroll en overflow molesto